### PR TITLE
Fix: Change default order of groups list to respect menu_order

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,0 +1,31 @@
+# CP Groups Documentation
+
+Welcome to the CP Groups documentation. CP Groups helps churches manage and display small groups, bible studies, classes, and other community groups on their WordPress website.
+
+## Documentation Structure
+
+### Getting Started
+- [Introduction](getting-started/introduction.md) - Overview, features, and key concepts
+- [Installation](getting-started/installation.md) - How to install, activate, and license
+- [Requirements](getting-started/requirements.md) - System requirements and dependencies
+
+### Configuration
+- [General Settings](configuration/general-settings.md) - Default thumbnail, labels, and archive page
+- [Advanced Settings](configuration/advanced-settings.md) - Facets, buttons, contact form, and spam protection
+
+### Groups
+- [Creating Groups](groups/creating-groups.md) - Add and configure individual groups
+- [Displaying Groups](groups/displaying-groups.md) - Archive page, filters, and search
+- [Shortcodes](groups/shortcodes.md) - Embed group lists with the cp-groups shortcode
+
+### Integrations
+- [CP Locations](integrations/cp-locations.md) - Per-location group configuration
+- [CP Sync](integrations/cp-sync.md) - Import groups from your church management system
+
+### Advanced Topics
+- [Troubleshooting](advanced/troubleshooting.md) - Common issues and solutions
+- [Developer Guide](advanced/developer-guide.md) - Hooks, filters, templates, and customization
+
+### Support
+- [FAQ](support/faq.md) - Frequently asked questions
+- [Getting Help](support/getting-help.md) - Support channels and resources

--- a/documentation/advanced/developer-guide.md
+++ b/documentation/advanced/developer-guide.md
@@ -1,0 +1,224 @@
+# Developer Guide
+
+This guide covers the hooks, filters, template system, and architecture of CP Groups for developers who want to extend or customize the plugin.
+
+## Architecture Overview
+
+CP Groups follows an MVC-like pattern:
+
+- **Models** (`CP_Groups\Models\Group`): Data layer for group post meta
+- **Controllers** (`CP_Groups\Controllers\Group`): Business logic and API data formatting
+- **Templates** (`templates/`): Frontend rendering with theme override support
+- **Settings** (`CP_Groups\Admin\Settings`): CMB2-based settings organized into option groups
+
+The plugin uses the ChurchPlugins core library for shared base classes and utilities.
+
+## Option Groups
+
+Settings are stored in four WordPress option groups:
+
+| Option Group | Contents |
+|--------------|----------|
+| `cp_groups_main_options` | Default thumbnail |
+| `cp_groups_group_options` | Labels, archive page, modal toggle |
+| `cp_groups_advanced_options` | Facets, buttons, contact form, spam protection |
+| `cp_groups_labels_options` | Taxonomy and badge labels |
+
+## Key Hooks
+
+### Actions
+
+```php
+// Fired when CP Groups loads its integrations
+do_action( 'cp_groups_load_integrations' );
+
+// Before and after the archive page content
+do_action( 'cp_groups_before_archive' );
+do_action( 'cp_after_archive' );
+
+// Before and after a single group page
+do_action( 'cp_before_group_single' );
+do_action( 'cp_after_group_single' );
+
+// After the content section in single group view
+// $item contains the group's API data array
+do_action( 'cp_group_single_after_content', $item );
+
+// Before and after the group modal
+do_action( 'cp_before_group_modal' );
+do_action( 'cp_after_group_modal' );
+```
+
+### Filters
+
+#### Settings
+
+```php
+// Filter any settings value
+// $value: the setting value, $key: setting key, $group: option group
+add_filter( 'cp_groups_settings_get', function( $value, $key, $group ) {
+    if ( $key === 'groups_per_page' ) {
+        return 20; // Override groups per page
+    }
+    return $value;
+}, 10, 3 );
+```
+
+#### Labels
+
+```php
+// Customize post type labels
+add_filter( 'cp_single_cp_group_label', function( $label ) {
+    return 'Community';
+} );
+
+add_filter( 'cp_plural_cp_group_label', function( $label ) {
+    return 'Communities';
+} );
+```
+
+#### Archive and Filters
+
+```php
+// Customize the archive page title
+add_filter( 'cp-groups-archive-title', function( $title ) {
+    return 'Find a Community';
+} );
+
+// Control archive page visibility programmatically
+add_filter( 'cp_groups_disable_archive', '__return_true' );
+
+// Modify which taxonomies appear in the filter panel
+add_filter( 'cp_groups_filter_facets', function( $taxonomies ) {
+    // Remove a taxonomy from filters
+    unset( $taxonomies['cp_group_life_stage'] );
+    return $taxonomies;
+} );
+
+// Modify terms shown in a taxonomy filter
+add_filter( 'cp_groups_filter_facet_terms', function( $terms, $taxonomy, $tax_obj ) {
+    // Filter terms for a specific taxonomy
+    return $terms;
+}, 10, 3 );
+
+// Customize facet link URLs
+add_filter( 'cp_groups_facet_link_uri', function( $uri, $slug, $facet ) {
+    return $uri;
+}, 10, 3 );
+```
+
+#### Shortcode
+
+```php
+// Modify the WP_Query parameters for the [cp-groups] shortcode
+add_filter( 'cp_groups_shortcode_query', function( $params ) {
+    $params['meta_key'] = 'is_group_full';
+    $params['meta_value'] = '0';
+    return $params;
+} );
+```
+
+#### Contact Form Emails
+
+```php
+// Customize the email subject
+add_filter( 'cp_groups_email_subject', function( $subject, $original_subject ) {
+    return '[Groups] ' . $original_subject;
+}, 10, 2 );
+
+// Customize the email message body
+add_filter( 'cp_groups_email_message', function( $message, $group_id ) {
+    return $message;
+}, 10, 2 );
+
+// Add a suffix to every email (e.g., disclaimer text)
+add_filter( 'cp_groups_email_message_suffix', function( $suffix, $group_id ) {
+    return $suffix . '<p>This message was sent from our website.</p>';
+}, 10, 2 );
+
+// Modify CC and BCC recipients
+add_filter( 'cp_groups_email_cc', function( $cc, $group_id ) {
+    return $cc;
+}, 10, 2 );
+
+add_filter( 'cp_groups_email_bcc', function( $bcc, $group_id ) {
+    return $bcc;
+}, 10, 2 );
+
+// Modify email headers (full control)
+add_filter( 'cp_groups_email_headers', function( $headers, $group_id ) {
+    return $headers;
+}, 10, 2 );
+```
+
+#### Taxonomy Registration
+
+```php
+// Add the group type taxonomy to additional post types
+add_filter( 'cp_group_type_taxonomy_types', function( $types ) {
+    $types[] = 'custom_post_type';
+    return $types;
+} );
+
+// Same pattern for category and life stage
+add_filter( 'cp_group_category_taxonomy_types', function( $types ) { return $types; } );
+add_filter( 'cp_group_life_stage_taxonomy_types', function( $types ) { return $types; } );
+```
+
+## Template Overrides
+
+Copy any template file from the plugin's `templates/` directory to your theme at `wp-content/themes/your-theme/cp-groups/` to override it:
+
+| Plugin Template | Theme Override Path |
+|-----------------|-------------------|
+| `templates/archive.php` | `cp-groups/archive.php` |
+| `templates/single.php` | `cp-groups/single.php` |
+| `templates/parts/group-list.php` | `cp-groups/parts/group-list.php` |
+| `templates/parts/group-single.php` | `cp-groups/parts/group-single.php` |
+| `templates/parts/group-modal.php` | `cp-groups/parts/group-modal.php` |
+| `templates/parts/filter.php` | `cp-groups/parts/filter.php` |
+| `templates/parts/filter-selected.php` | `cp-groups/parts/filter-selected.php` |
+| `templates/parts/pagination.php` | `cp-groups/parts/pagination.php` |
+| `templates/shortcodes/group-list.php` | `cp-groups/shortcodes/group-list.php` |
+| `templates/shortcodes/filter.php` | `cp-groups/shortcodes/filter.php` |
+
+## Group API Data
+
+The `CP_Groups\Controllers\Group::get_api_data()` method returns structured data for each group:
+
+```php
+[
+    'id'               => 123,
+    'originID'         => '456',
+    'permalink'        => 'https://example.com/groups/young-adults/',
+    'slug'             => 'young-adults',
+    'thumb'            => 'https://example.com/wp-content/uploads/group.jpg',
+    'title'            => 'Young Adults Bible Study',
+    'desc'             => '<p>Full description...</p>',
+    'excerpt'          => 'Short excerpt...',
+    'date'             => [ 'desc' => 'January 15, 2024', 'timestamp' => 1705344000 ],
+    'contact_url'      => 'mailto:leader@example.com',
+    'registration_url' => 'https://example.com/register',
+    'categories'       => [ /* taxonomy terms */ ],
+    'locations'        => [ /* location terms */ ],
+    'types'            => [ /* type terms */ ],
+    'lifeStages'       => [ /* life stage terms */ ],
+    'startTime'        => 'Thursdays at 6:00 PM',
+    'leader'           => 'John Smith',
+    'location'         => 'North Campus, Room 201',
+    'handicap'         => 'on',
+    'kidFriendly'      => 'on',
+    'isFull'           => false,
+    'meetsOnline'      => false,
+]
+```
+
+## Constants
+
+| Constant | Description |
+|----------|-------------|
+| `CP_GROUPS_PLUGIN_DIR` | Absolute path to the plugin directory |
+| `CP_GROUPS_PLUGIN_URL` | URL to the plugin directory |
+| `CP_GROUPS_INCLUDES` | Path to the `includes/` directory |
+
+For more help, see the [Troubleshooting](troubleshooting.md) guide.

--- a/documentation/advanced/troubleshooting.md
+++ b/documentation/advanced/troubleshooting.md
@@ -1,0 +1,102 @@
+# Troubleshooting
+
+This guide covers common issues with CP Groups and how to resolve them.
+
+## Archive Page Issues
+
+### Archive Page Returns 404
+
+1. Go to **Settings → Permalinks** in the WordPress admin
+2. Click **Save Changes** without making any modifications — this flushes the rewrite rules
+3. Try visiting `/groups/` again
+4. If the issue persists, verify **Disable Archive Page** is unchecked in **Groups → Settings → Main**
+
+### Archive Page Shows Wrong Groups
+
+1. Check for active filters in the URL — clear them by visiting `/groups/` directly
+2. Verify groups are published (not in draft or pending status)
+3. If using CP Sync, confirm the latest sync completed successfully
+
+## Filter Issues
+
+### Taxonomy Filters Not Showing
+
+1. Taxonomies with no assigned terms are automatically hidden — assign at least one group to a term
+2. Verify the taxonomy exists under **Groups** in the admin sidebar
+3. Check that you have not removed the taxonomy via a custom filter on `cp_groups_filter_facets`
+
+### Badge Filters Not Showing
+
+1. Navigate to **Groups → Settings → Advanced**
+2. Verify the corresponding badge filter is enabled (Kid Friendly, Wheelchair Accessible, Meets Online)
+3. The Show/Hide Full Groups filter must be set to **Hide** or **Show** (not **Disable**)
+
+### Filters Not Working
+
+1. Check for JavaScript errors in your browser's developer console
+2. Verify no caching plugin is serving stale pages — clear all caches
+3. Test in an incognito window to rule out browser extensions
+
+## Contact Form Issues
+
+### Form Not Appearing
+
+1. Navigate to **Groups → Settings → Advanced**
+2. Verify **Contact Action** is set to **Use Contact Form**
+3. Confirm the group has a **Group Leader Email** address entered
+4. Check that the contact button is not hidden (Advanced Settings → **Hide Contact** should be unchecked)
+
+### Emails Not Sending
+
+1. Verify WordPress can send emails — install a test plugin like WP Mail SMTP
+2. Check the **From Email** and **From Name** in Advanced Settings
+3. Verify the group leader's email address is valid
+4. Check your server's email logs for delivery failures
+
+### Rate Limit Reached
+
+If you or a tester hits the rate limit during testing:
+
+1. The limit resets daily (tracked by date)
+2. To reset immediately, delete the rate limit option from the database:
+   - Look for rows with `option_name` starting with `cp_ratelimit_` in the `wp_options` table
+
+### reCAPTCHA Not Working
+
+1. Verify your site key and secret key are entered correctly in Advanced Settings
+2. Confirm your domain is registered in the [Google reCAPTCHA console](https://www.google.com/recaptcha/admin)
+3. Check the browser console for reCAPTCHA loading errors
+4. Ensure no other plugin or security rule is blocking Google's reCAPTCHA scripts
+
+## Display Issues
+
+### Group Modal Not Opening
+
+1. Check for JavaScript errors in your browser's developer console
+2. Verify jQuery and jQuery UI Dialog are loading (these are required dependencies)
+3. Test with a default WordPress theme to rule out theme conflicts
+4. Confirm **Disable Modal** is unchecked in **Groups → Settings → Main**
+
+### Missing Group Information
+
+1. Open the group in the editor and verify the fields are filled in
+2. Check that the corresponding badge or button is enabled in Advanced Settings
+3. If using template overrides, verify your custom templates include the relevant fields
+4. Clear any page or object cache
+
+### Default Thumbnail Not Showing
+
+1. Verify a default thumbnail is uploaded in **Groups → Settings → Main**
+2. Check that the image file still exists in the media library
+3. If the group has a featured image set, it takes priority over the default thumbnail
+
+## Performance Issues
+
+### Slow Archive Page
+
+1. Reduce the **Groups Per Page** setting in Advanced Settings
+2. Optimize group images — large images slow down page loads
+3. Ensure your hosting environment has adequate PHP memory
+4. Consider enabling a page cache plugin
+
+For additional help, see the [Getting Help](../support/getting-help.md) guide.

--- a/documentation/configuration/advanced-settings.md
+++ b/documentation/configuration/advanced-settings.md
@@ -1,0 +1,94 @@
+# Advanced Settings
+
+The Advanced Settings page gives you control over the filter system, button visibility, and the built-in contact form including spam protection options.
+
+## Accessing Advanced Settings
+
+1. Log in to your WordPress admin dashboard
+2. Navigate to **Groups → Settings**
+3. Click the **Advanced** tab
+
+## Facet Settings
+
+Facets are the filter controls that appear on the group archive page and in the `[cp-groups-filter]` shortcode. These settings control which attribute filters are available to visitors.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| **Kid Friendly** | Enabled | Show or hide the Kid Friendly checkbox filter |
+| **Wheelchair Accessible** | Enabled | Show or hide the Wheelchair Accessible checkbox filter |
+| **Meets Online** | Enabled | Show or hide the Meets Online checkbox filter |
+| **Show/Hide Full Groups** | Hide | Controls the Group is Full filter. **Hide**: enabled, full groups hidden by default. **Show**: enabled, full groups shown by default. **Disable**: no filter shown. |
+| **Groups Per Page** | 40 | Number of groups displayed per page (range: 10–100) |
+
+### How Full Groups Work
+
+When the full groups filter is set to **Hide** (the default), groups marked as full are hidden from the listing. Visitors can click a "Show Full Groups" toggle to reveal them. When set to **Show**, full groups appear by default and visitors can hide them.
+
+## Button Settings
+
+Control which action buttons appear on group cards and detail views:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| **Hide Registration** | Unchecked | Hide the registration button on all groups |
+| **Hide Details** | Unchecked | Hide the details/view details button on all groups |
+| **Contact Action** | Use Contact Action | Controls the contact button behavior |
+
+### Contact Action Options
+
+- **Use Contact Action**: Uses the Contact Action field from each group (a URL or email address)
+- **Use Contact Form**: Displays the built-in contact form (see Contact Form Settings below)
+- **Hide**: Hides the contact button entirely
+
+## Contact Form Settings
+
+These settings configure the built-in contact form. The contact form appears when **Contact Action** is set to **Use Contact Form**, or when a group's **Registration Action** is an email address. The form lets visitors send messages directly to group leaders from the group modal or single page.
+
+### Email Configuration
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| **Show Leader Email** | Unchecked | Display the group leader's email address inside the contact form |
+| **From Email** | Site admin email | The "From" address on outgoing emails |
+| **From Name** | Site title | The "From" name on outgoing emails |
+| **CC** | Empty | Email addresses to CC on all contact form submissions (comma-separated) |
+| **BCC** | Empty | Email addresses to BCC on all contact form submissions (comma-separated) |
+
+Individual groups can also have their own CC addresses set in the group editor, which are combined with the global CC setting.
+
+### Spam Protection
+
+CP Groups includes multiple layers of spam protection for the contact form:
+
+**Rate Limiting (Throttling)**
+
+- **Throttle Emails**: Enable rate limiting to prevent abuse
+- **Throttle Amount**: Maximum number of submissions per day from the same person (range: 2–10, default: 3)
+- Tracks submissions by both IP address and email address
+
+**Staff Email Blocking**
+
+- **Block Staff Emails**: Prevent submissions from email addresses that contain your site's domain name (enabled by default)
+- For example, if your site is `example.com`, submissions from `staff@example.com` are blocked
+
+**Honeypot Field**
+
+- **Enable Honeypot**: Adds a hidden field that bots fill in but humans do not
+- Submissions with the honeypot field filled are rejected with an error
+
+**reCAPTCHA v3**
+
+- **Enable reCAPTCHA**: Adds Google reCAPTCHA v3 verification to the form
+- **Site Key**: Your reCAPTCHA v3 site key from the [Google reCAPTCHA console](https://www.google.com/recaptcha/admin)
+- **Secret Key**: Your reCAPTCHA v3 secret key
+- Submissions are verified server-side with a minimum score threshold of 0.5
+
+## Troubleshooting
+
+If your advanced settings are not behaving as expected:
+
+- Verify that WordPress cron is running properly if rate limiting does not reset daily
+- Check that your reCAPTCHA keys match the domain registered in the Google console
+- Test the contact form in an incognito window to rule out caching issues
+
+For more help, see the [Troubleshooting](../advanced/troubleshooting.md) guide.

--- a/documentation/configuration/general-settings.md
+++ b/documentation/configuration/general-settings.md
@@ -1,0 +1,82 @@
+# General Settings
+
+The General Settings page lets you configure your default group thumbnail, customize labels, and control the archive page. This is the first place to set up after activating CP Groups.
+
+## Accessing General Settings
+
+1. Log in to your WordPress admin dashboard
+2. Navigate to **Groups → Settings**
+3. The **Main** tab is selected by default
+
+![CP Groups settings page](https://docs.churchplugins.com/wp-content/uploads/sites/2/2024/03/Screenshot-2024-03-04-at-9.17.56%20AM-1024x315.png)
+
+## Main Tab
+
+### Default Thumbnail
+
+Upload a default thumbnail image that displays for groups without a featured image. This keeps your group listings looking consistent even when individual group images are not set.
+
+1. Click **Upload/Add Image** next to the Default Thumbnail field
+2. Select or upload an image from the media library
+3. Click **Save Changes**
+
+## Groups Tab
+
+Click the **Groups** tab to access label and archive settings.
+
+### Group Labels
+
+Customize the singular and plural labels used for the group post type throughout the admin and frontend:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| **Singular Label** | Group | Used in headings, buttons, and admin menus (e.g., "Add New Group") |
+| **Plural Label** | Groups | Used in archive titles, navigation, and list headings (e.g., "All Groups") |
+
+### Archive Page
+
+By default, CP Groups creates a public archive page at `/groups/` that displays all your groups with filters and search.
+
+- **Disable Archive Page**: Check this box to hide the archive page. Use this if you prefer to display groups only through shortcodes on specific pages.
+
+### Modal Display
+
+By default, clicking a group in the list opens a popup modal with the group's full details.
+
+- **Disable Modal**: Check this box to link directly to the group's single page instead of opening a modal. Use this if you want groups to have their own dedicated pages.
+
+## Labels Tab
+
+Click the **Labels** tab to customize taxonomy and badge labels. These labels appear in the admin sidebar, filter dropdowns, and badge displays.
+
+### Taxonomy Labels
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| **Type Singular / Plural** | Type / Types | Label for the group type taxonomy (e.g., "Ministry" / "Ministries") |
+| **Category Singular / Plural** | Category / Categories | Label for the group category taxonomy |
+| **Life Stage Singular / Plural** | Life Stage / Life Stages | Label for the life stage taxonomy (e.g., "Age Group" / "Age Groups") |
+
+### Badge Labels
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| **Kid Friendly** | Kid Friendly | Text displayed on the kid friendly badge |
+| **Wheelchair Accessible** | Wheelchair Accessible | Text displayed on the accessible badge |
+| **Meets Online** | Meets Online | Text displayed on the meets online badge |
+
+## Applying Settings
+
+1. Click **Save Changes** at the bottom of the page
+2. The page refreshes with a confirmation message
+
+After changing labels, visit **Groups** in the admin sidebar to see the updated terminology. Taxonomy labels also update in the frontend filter dropdowns.
+
+## Troubleshooting
+
+If your settings are not taking effect:
+
+- Clear any page cache or object cache on your site
+- If the archive page returns a 404 after enabling or disabling it, go to **Settings → Permalinks** and click **Save Changes** to flush rewrite rules
+
+For more help, see the [Troubleshooting](../advanced/troubleshooting.md) guide.

--- a/documentation/getting-started/installation.md
+++ b/documentation/getting-started/installation.md
@@ -1,0 +1,57 @@
+# Installation
+
+This guide walks you through installing and activating CP Groups on your WordPress site.
+
+## Prerequisites
+
+Before installing CP Groups:
+
+- A WordPress site running version 5.0 or higher
+- PHP 7.0 or higher
+- A valid CP Groups license key from [ChurchPlugins](https://churchplugins.com)
+
+## Installing the Plugin
+
+### Upload via WordPress Admin
+
+1. Log in to your WordPress admin dashboard
+2. Navigate to **Plugins → Add New**
+3. Click the **Upload Plugin** button at the top of the page
+4. Select the CP Groups ZIP file you downloaded from ChurchPlugins — do not extract the ZIP first
+5. Click **Install Now**
+6. Click **Activate Plugin** after the installation completes
+
+### Installing via FTP
+
+If you prefer to install manually:
+
+1. Download the CP Groups ZIP file from your ChurchPlugins account
+2. Extract the ZIP file on your computer
+3. Upload the `cp-groups` folder to `wp-content/plugins/` on your server using an FTP client
+4. Log in to your WordPress admin dashboard
+5. Navigate to **Plugins → Installed Plugins**
+6. Find **CP Groups** in the list and click **Activate**
+
+## Activating Your License
+
+1. Navigate to **Groups → Settings**
+2. Click the **License** tab
+3. Enter your license key in the **License Key** field
+4. Click **Activate License**
+5. Verify that the license status shows as **Active**
+
+### Beta Updates
+
+If you want early access to new features, enable beta updates on the License tab. Beta versions may contain experimental features and should be tested before use on a production site.
+
+## Verifying the Installation
+
+After activation, confirm the plugin is working:
+
+1. Navigate to **Groups → Settings**
+2. Verify you see the settings tabs: **Main**, **Groups**, **Advanced**, **Labels**, and **License**
+3. Visit the frontend of your site and navigate to `/groups/` to see the archive page
+
+## Next Steps
+
+Continue to [General Settings](../configuration/general-settings.md) to configure your group labels, default thumbnail, and archive page options.

--- a/documentation/getting-started/introduction.md
+++ b/documentation/getting-started/introduction.md
@@ -1,0 +1,47 @@
+# Introduction to CP Groups
+
+CP Groups is a WordPress plugin that helps churches manage and display small groups, bible studies, classes, and other community groups on their website. It gives church members an easy way to discover and connect with groups that fit their interests and schedule.
+
+## What CP Groups Does
+
+CP Groups provides a complete system for managing group information and helping visitors find the right group:
+
+- **Group Management**: Create and manage groups with details like leader name, meeting time, location, and registration links
+- **Filterable Directory**: An archive page with search, taxonomy filters, and attribute filters so visitors can find groups that match their needs
+- **Contact Form**: Built-in contact form lets visitors message group leaders directly from your site, with spam protection included
+- **Shortcodes**: Embed group lists on any page with taxonomy-based filtering
+- **Customizable Labels**: Rename taxonomies and labels to match your church's terminology
+- **Template Overrides**: Customize the look and feel by overriding templates in your theme
+
+## Key Concepts
+
+Understanding a few core concepts helps you get the most out of CP Groups:
+
+- **Groups**: A custom post type (`cp_group`) that stores all group information including leader details, meeting times, location, and status flags
+- **Taxonomies**: Three built-in taxonomies for categorizing groups — Type, Category, and Life Stage. Each can be renamed to match your church's language.
+- **Badges**: Visual indicators on group cards for attributes like Kid Friendly, Wheelchair Accessible, and Meets Online
+- **Facets**: The filter controls on the archive page that let visitors narrow down groups by taxonomy, badge, or search term
+- **Modal vs. Single Page**: Groups can open in a popup modal (default) or link to a dedicated single page
+
+## Group Attributes
+
+Each group can include the following information:
+
+- **Group Leader** and **Leader Email** for contact purposes
+- **Meeting Time Description** (e.g., "Thursdays at 6:00 PM")
+- **Meeting Location** (e.g., "North Campus, Room 201")
+- **Status Flags**: Kid Friendly, Wheelchair Accessible, Meets Online, Group is Full
+- **Registration Action**: A URL or email address for the registration button
+- **Contact Action**: A URL, email address, or the built-in contact form
+- **Details Link**: An external URL for additional group information
+
+## Supported Integrations
+
+CP Groups works with other ChurchPlugins products:
+
+- **CP Locations**: Assign groups to locations and configure per-location email routing
+- **CP Sync**: Automatically import groups from your church management system (Planning Center, CCB)
+
+## Next Steps
+
+Continue to [Installation](installation.md) to get CP Groups set up on your site.

--- a/documentation/getting-started/requirements.md
+++ b/documentation/getting-started/requirements.md
@@ -1,0 +1,38 @@
+# Requirements
+
+This document outlines the system requirements and dependencies for running CP Groups on your WordPress site.
+
+## System Requirements
+
+| Requirement | Minimum Version |
+|-------------|----------------|
+| WordPress   | 5.0+           |
+| PHP         | 7.0+           |
+| MySQL       | 5.6+           |
+
+## Browser Compatibility
+
+CP Groups works in all modern browsers:
+
+- Chrome 60+
+- Firefox 55+
+- Safari 11+
+- Edge 79+
+
+The group archive, filters, and modal use jQuery and standard WordPress scripts that are compatible with these browsers.
+
+## Optional Dependencies
+
+- **CP Locations**: Required for assigning groups to locations and per-location email routing. Install and activate CP Locations before enabling location features. See [CP Locations Integration](../integrations/cp-locations.md) for details.
+- **CP Sync**: Required for importing groups from a church management system. See [CP Sync Integration](../integrations/cp-sync.md) for setup instructions.
+
+## reCAPTCHA Requirements
+
+If you plan to use reCAPTCHA on the contact form:
+
+- A Google reCAPTCHA v3 site key and secret key from the [Google reCAPTCHA admin console](https://www.google.com/recaptcha/admin)
+- Your domain must be registered in the reCAPTCHA console
+
+## Next Steps
+
+Continue to [Installation](installation.md) to install and activate CP Groups.

--- a/documentation/groups/creating-groups.md
+++ b/documentation/groups/creating-groups.md
@@ -1,0 +1,83 @@
+# Creating Groups
+
+This guide walks you through adding and configuring individual groups in CP Groups. Each group is a custom post type with fields for leader information, meeting details, status badges, and action links.
+
+## Adding a New Group
+
+1. Navigate to **Groups → Add New**
+2. Enter the group **Title** (e.g., "Young Adults Bible Study")
+3. Add a **Description** in the content editor — this appears in the group modal or single page
+4. Set a **Featured Image** to display as the group thumbnail (falls back to the default thumbnail if not set)
+5. Fill in the group-specific fields described below
+6. Assign the group to one or more taxonomies (Type, Category, Life Stage)
+7. Click **Publish**
+
+## Group Fields
+
+### Basic Information
+
+| Field | Description |
+|-------|-------------|
+| **Group Leader** | The name of the group leader, displayed on the group card |
+| **Group Leader Email** | The leader's email address, used as the recipient for contact form submissions |
+| **CC** | Additional email addresses to CC when this group receives a contact form submission (comma-separated) |
+| **Meeting Time Desc** | A text description of when the group meets (e.g., "Thursdays at 6:00 PM") |
+| **Meeting Location** | Where the group meets (e.g., "North Campus, Room 201") |
+
+### Status Badges
+
+These checkboxes control visual badges that appear on the group card and in the filter system:
+
+| Badge | Description |
+|-------|-------------|
+| **Kid Friendly** | Indicates the group is kid-friendly or provides childcare |
+| **Wheelchair Accessible** | Indicates the meeting location is wheelchair accessible |
+| **Meets Online** | Indicates the group meets virtually |
+| **Group is Full** | Marks the group as full — hides the registration button and optionally hides the group from listings |
+
+### Action Links
+
+These fields control the buttons that appear on each group:
+
+| Field | Description |
+|-------|-------------|
+| **Group Details** | A URL linking to an external page with more information about the group. Controls the "View Details" button. |
+| **Registration Action** | A URL or email address for the registration button. Enter a URL to link to an external registration page, or an email address to open the visitor's email client. |
+| **Contact Action** | A URL or email address for the contact button. This field is used when the Advanced Settings contact action is set to **Use Contact Action**. If set to **Use Contact Form**, this field is ignored and the built-in form is shown instead. |
+
+## Taxonomies
+
+Assign groups to taxonomies to enable filtering on the archive page. These taxonomy labels can be customized in [General Settings](../configuration/general-settings.md).
+
+- **Type** (`cp_group_type`): The type of group — e.g., Small Group, Bible Study, Service Team
+- **Category** (`cp_group_category`): A flexible category for additional organization — e.g., Men, Women, Couples
+- **Life Stage** (`cp_group_life_stage`): The target audience — e.g., Young Adults, College, Seniors
+
+Taxonomies with no terms assigned are hidden from the frontend filter panel.
+
+## Managing Groups
+
+### Editing a Group
+
+1. Navigate to **Groups → All Groups**
+2. Click the group title to open the editor
+3. Make your changes
+4. Click **Update**
+
+### Reordering Groups
+
+Groups support page attributes, including menu order. Set the **Order** field in the Page Attributes panel to control the display order. By default, groups are sorted alphabetically by title.
+
+### Bulk Actions
+
+Use the WordPress bulk actions menu on the **All Groups** screen to move multiple groups to trash, or use the Quick Edit option to change taxonomy assignments.
+
+## Troubleshooting
+
+If group fields are not displaying on the frontend:
+
+- Verify the field is filled in and saved
+- Check that the corresponding badge or button is not disabled in [Advanced Settings](../configuration/advanced-settings.md)
+- Clear any page cache on your site
+
+For more help, see the [Troubleshooting](../advanced/troubleshooting.md) guide.

--- a/documentation/groups/displaying-groups.md
+++ b/documentation/groups/displaying-groups.md
@@ -1,0 +1,86 @@
+# Displaying Groups
+
+CP Groups provides an archive page, filters, and a modal system for displaying groups to visitors. This guide covers how the frontend display works and how to configure it.
+
+## Archive Page
+
+By default, CP Groups creates a public archive page at `/groups/`. The page displays a filter panel on the left and the group list on the right.
+
+To disable the archive page, check **Disable Archive Page** in [General Settings](../configuration/general-settings.md). You can then use shortcodes to display groups on specific pages instead.
+
+![Group archive page with filters and group cards](https://docs.churchplugins.com/wp-content/uploads/sites/2/2023/07/Screen-Shot-2023-07-05-at-1.02.34-PM-1024x305.png)
+
+### Archive Page Layout
+
+The archive page includes:
+
+- **Search bar**: Full-text search across group titles and descriptions
+- **Taxonomy filters**: Dropdown checkboxes for each taxonomy with assigned terms (Type, Category, Life Stage)
+- **Attribute filters**: Checkbox filters for Kid Friendly, Wheelchair Accessible, Meets Online, and Show/Hide Full Groups
+- **Group cards**: Each group displays its title, thumbnail, leader, meeting time, location, badges, and action buttons
+- **Pagination**: Controlled by the **Groups Per Page** setting in [Advanced Settings](../configuration/advanced-settings.md) (default: 40)
+
+### Filter Behavior
+
+Filters update the group list dynamically. When a visitor selects a filter:
+
+1. The page reloads with the filter applied as a URL parameter
+2. Active filters appear as removable badges above the group list
+3. Multiple filters can be combined (e.g., "Young Adults" + "Kid Friendly")
+4. Taxonomy filters with no assigned terms are automatically hidden
+
+## Group Modal
+
+By default, clicking a group card opens a popup modal with the full group details. The modal includes:
+
+- Group title and description
+- Leader name and meeting details
+- All assigned badges
+- Action buttons (Registration, Contact, Details)
+
+To disable the modal and link directly to the group's single page instead, check **Disable Modal** in [General Settings](../configuration/general-settings.md).
+
+## Group Single Page
+
+Each group has a dedicated single page at `/groups/{group-slug}/`. This page shows the same information as the modal but as a full page with your theme's header and footer.
+
+The single page is always accessible by URL, even when the modal is enabled.
+
+## Template Overrides
+
+Customize the display by copying template files to your theme. Place override files in `wp-content/themes/your-theme/cp-groups/`:
+
+| Template File | Purpose |
+|---------------|---------|
+| `archive.php` | Main archive page layout |
+| `single.php` | Single group page wrapper |
+| `parts/group-list.php` | Individual group card in the list |
+| `parts/group-single.php` | Full group detail view |
+| `parts/group-modal.php` | Group modal popup |
+| `parts/filter.php` | Filter/search form |
+| `parts/filter-selected.php` | Active filter badges |
+| `parts/pagination.php` | Pagination controls |
+| `shortcodes/group-list.php` | `[cp-groups]` shortcode output |
+| `shortcodes/filter.php` | `[cp-groups-filter]` shortcode output |
+
+## CSS Body Classes
+
+CP Groups does not add custom body classes, but you can target group pages using WordPress default classes:
+
+```css
+/* Archive page */
+.post-type-archive-cp_group .group-card { }
+
+/* Single group page */
+.single-cp_group .group-details { }
+```
+
+## Troubleshooting
+
+If the archive page returns a 404:
+
+1. Go to **Settings → Permalinks** in the WordPress admin
+2. Click **Save Changes** without making any changes — this flushes the rewrite rules
+3. Try visiting `/groups/` again
+
+For more help, see the [Troubleshooting](../advanced/troubleshooting.md) guide.

--- a/documentation/groups/shortcodes.md
+++ b/documentation/groups/shortcodes.md
@@ -1,0 +1,86 @@
+# Shortcodes
+
+CP Groups provides shortcodes to display group lists and filters on any page or post. Use shortcodes when you want to embed groups outside the archive page or filter to specific groups.
+
+## Available Shortcodes
+
+### `[cp-groups]`
+
+Displays a paginated list of groups. Place this on any page where you want groups to appear.
+
+**Basic usage:**
+
+```html
+[cp-groups]
+```
+
+This displays all published groups with pagination.
+
+### Filtering by Taxonomy
+
+You can filter the shortcode output to show only groups from specific taxonomy terms. Pass the taxonomy slug as an attribute with the term slug(s) as the value.
+
+**Show only groups of a specific type:**
+
+```html
+[cp-groups cp_group_type="small-group"]
+```
+
+**Show only groups for a specific life stage:**
+
+```html
+[cp-groups cp_group_life_stage="young-adults"]
+```
+
+**Show groups matching multiple terms** (comma-separated):
+
+```html
+[cp-groups cp_group_type="small-group,bible-study"]
+```
+
+### Finding Taxonomy Slugs
+
+To find the slug for a taxonomy term:
+
+1. Navigate to **Groups → [Taxonomy Name]** (e.g., Groups → Types)
+2. Hover over the term you want to use
+3. The slug appears in the **Slug** column of the table
+
+### `[cp-groups-filter]`
+
+Displays the filter panel (search, taxonomy dropdowns, and attribute checkboxes) without the group list. Use this when you want to place filters separately from the group list on the same page.
+
+```html
+[cp-groups-filter]
+```
+
+## Creating a Groups Page
+
+A typical groups page setup using shortcodes:
+
+1. Create a new page in WordPress (e.g., "Small Groups")
+2. Add the `[cp-groups]` shortcode to display all groups, or filter to specific terms
+3. Publish the page
+4. Add the page to your site's navigation menu
+
+If you only need to display certain groups (e.g., just young adult groups), the shortcode approach is simpler than the archive page since you can pre-filter the results.
+
+## Shortcodes vs. Archive Page
+
+| Feature | Archive Page | Shortcodes |
+|---------|-------------|------------|
+| Built-in filters | Yes | Only with `[cp-groups-filter]` |
+| Taxonomy filtering | Via frontend filters | Via shortcode attributes |
+| Custom page placement | Fixed at `/groups/` | Any page |
+| Theme template | Uses archive template | Uses page template |
+
+## Troubleshooting
+
+If the shortcode displays no groups:
+
+- Verify that published groups exist
+- Check that the taxonomy slug and term slug are correct (use lowercase with hyphens)
+- Make sure there are no typos in the shortcode attributes
+- Clear any page cache on your site
+
+For more help, see the [Troubleshooting](../advanced/troubleshooting.md) guide.

--- a/documentation/integrations/cp-locations.md
+++ b/documentation/integrations/cp-locations.md
@@ -1,0 +1,68 @@
+# CP Locations Integration
+
+CP Groups integrates with CP Locations to enable location-based group organization and per-location email routing. When active, groups can be assigned to locations and each location can have its own CC and BCC email settings for contact form submissions.
+
+## Prerequisites
+
+Before setting up location-based groups:
+
+- CP Locations plugin is installed and activated
+- At least one location is created in CP Locations
+- CP Groups is installed, activated, and licensed
+
+## How the Integration Works
+
+When CP Locations is active, CP Groups automatically:
+
+1. Adds the location taxonomy (`cp_location`) to the group post type, so groups can be assigned to locations
+2. Adds group-specific email settings to each location's edit screen
+3. Includes location-based CC and BCC addresses in contact form emails
+
+No manual activation is required — the integration loads automatically when CP Locations is detected.
+
+## Assigning Groups to Locations
+
+1. Open a group in the editor (**Groups → All Groups → [Group Name]**)
+2. In the **Location** taxonomy panel (sidebar), check one or more locations
+3. Click **Update**
+
+Groups assigned to locations can be filtered by location on the archive page, just like any other taxonomy.
+
+## Location Email Settings
+
+Each location can have its own email routing for group contact form submissions:
+
+1. Navigate to the location edit screen in **CP Locations**
+2. Scroll to the **Group Settings** metabox
+3. Configure the following fields:
+
+| Field | Description |
+|-------|-------------|
+| **Group Email CC** | Email addresses to CC on contact form submissions for groups at this location (comma-separated) |
+| **Group Email BCC** | Email addresses to BCC on contact form submissions for groups at this location (comma-separated) |
+
+These addresses are combined with the global CC/BCC settings from [Advanced Settings](../configuration/advanced-settings.md) and any per-group CC addresses.
+
+## Email Routing Summary
+
+When a visitor submits the contact form for a group, the email recipients are compiled from multiple sources:
+
+1. **To**: The group leader's email address
+2. **CC**: Global CC setting + group-specific CC field + location CC field
+3. **BCC**: Global BCC setting + location BCC field
+
+## Troubleshooting
+
+### Location Taxonomy Not Showing
+
+1. Verify CP Locations is installed and activated
+2. Deactivate and reactivate CP Groups to re-trigger the integration
+3. Check that locations have been created in CP Locations
+
+### Location Emails Not Sending
+
+1. Verify the CC/BCC fields are filled in on the location edit screen
+2. Confirm the contact form is working for non-location groups first
+3. Check that the group is assigned to the correct location
+
+For more help, see the [Troubleshooting](../advanced/troubleshooting.md) guide.

--- a/documentation/integrations/cp-sync.md
+++ b/documentation/integrations/cp-sync.md
@@ -1,0 +1,69 @@
+# CP Sync Integration
+
+CP Groups integrates with CP Sync to automatically import groups from your church management system (ChMS). This keeps your website's group listings up to date without manual data entry.
+
+## Prerequisites
+
+Before setting up group synchronization:
+
+- CP Sync is installed, activated, and licensed
+- CP Groups is installed, activated, and licensed
+- Your ChMS account is connected in CP Sync settings
+
+## Supported Church Management Systems
+
+CP Sync imports group data from:
+
+- **Planning Center Online (PCO)**: Imports groups from PCO Groups
+- **Church Community Builder (CCB)**: Imports groups from CCB's group system
+
+## How It Works
+
+1. CP Sync connects to your ChMS via API
+2. Group data is pulled based on your sync configuration and filters
+3. CP Sync creates or updates `cp_group` posts in WordPress with the imported data
+4. Fields like group name, description, leader, meeting time, and location are mapped to CP Groups fields
+5. Taxonomy terms (Type, Category, Life Stage) can be mapped from ChMS categories
+
+Syncs can run on a schedule (hourly, daily, weekly) or be triggered manually from the CP Sync settings.
+
+## What Gets Imported
+
+| ChMS Field | CP Groups Field |
+|------------|----------------|
+| Group name | Post title |
+| Description | Post content |
+| Group image | Featured image |
+| Leader name | Group Leader |
+| Leader email | Group Leader Email |
+| Meeting time | Meeting Time Desc |
+| Meeting location | Meeting Location |
+| Group type/category | Taxonomy terms |
+
+The exact fields available depend on your ChMS and what data is configured in CP Sync's field mapping.
+
+## After Import
+
+Once groups are imported:
+
+- They appear in **Groups → All Groups** in the admin
+- They display on the archive page and in shortcodes like any manually created group
+- You can edit imported groups to add additional details (badges, action links)
+- Subsequent syncs update existing groups rather than creating duplicates
+
+## Troubleshooting
+
+### Groups Not Importing
+
+1. Verify your ChMS connection is active in **Settings → CP Sync**
+2. Check CP Sync's logs for error messages
+3. Confirm groups exist and are visible in your ChMS
+4. Run a manual sync to test
+
+### Imported Data Missing Fields
+
+1. Review the field mapping in CP Sync settings
+2. Verify the data exists in your ChMS for the affected groups
+3. Some fields may not be available from all ChMS platforms
+
+For more help, see the CP Sync documentation or the [Troubleshooting](../advanced/troubleshooting.md) guide.

--- a/documentation/support/faq.md
+++ b/documentation/support/faq.md
@@ -1,0 +1,82 @@
+# Frequently Asked Questions
+
+## General
+
+### What is CP Groups?
+
+CP Groups is a WordPress plugin that helps churches manage and display small groups, bible studies, classes, and other community groups. It provides a filterable directory, contact form, and shortcodes for embedding groups on your site.
+
+### Does CP Groups work with any WordPress theme?
+
+Yes, CP Groups works with any WordPress theme. It uses standard WordPress post types, shortcodes, and templates. You can further customize the display by overriding templates in your theme. See the [Developer Guide](../advanced/developer-guide.md) for template override details.
+
+### Can I rename the taxonomies?
+
+Yes. Navigate to **Groups → Settings → Labels** to customize the singular and plural labels for Type, Category, and Life Stage. You can also rename the badge labels (Kid Friendly, Wheelchair Accessible, Meets Online).
+
+## Setup and Configuration
+
+### How do I create the groups page?
+
+CP Groups automatically creates an archive page at `/groups/` when activated. If you prefer to use a custom page, disable the archive in [General Settings](../configuration/general-settings.md) and use the `[cp-groups]` shortcode on any page. See [Shortcodes](../groups/shortcodes.md) for details.
+
+### How do I set up the contact form?
+
+1. Navigate to **Groups → Settings → Advanced**
+2. Set **Contact Action** to **Use Contact Form**
+3. Ensure each group has a **Group Leader Email** entered
+4. Optionally enable spam protection (honeypot, reCAPTCHA, rate limiting)
+
+See [Advanced Settings](../configuration/advanced-settings.md) for full configuration details.
+
+### Can I have multiple groups pages showing different groups?
+
+Yes. Use the `[cp-groups]` shortcode with taxonomy filtering to show specific groups on different pages. For example, `[cp-groups cp_group_type="small-group"]` on one page and `[cp-groups cp_group_type="bible-study"]` on another.
+
+## Groups
+
+### How do I mark a group as full?
+
+Open the group in the editor, check the **Group is Full** checkbox, and click **Update**. Full groups have their registration button hidden and can be hidden from the archive listing depending on the full groups filter setting.
+
+### Can visitors contact group leaders directly?
+
+Yes, when the contact form is enabled. Visitors fill out a form with their name, email, subject, and message. The email is sent to the group leader's email address, with optional CC/BCC recipients.
+
+### How does the registration button work?
+
+The registration button uses the **Registration Action** field on each group. Enter a URL to link to an external registration page, or enter an email address to open the visitor's email client. To hide registration buttons globally, check **Hide Registration** in [Advanced Settings](../configuration/advanced-settings.md).
+
+## Filters and Display
+
+### Why are some taxonomy filters hidden?
+
+Taxonomy filters are automatically hidden when no groups are assigned to terms in that taxonomy. Assign at least one group to a term for the filter to appear.
+
+### Can I change how many groups show per page?
+
+Yes. Navigate to **Groups → Settings → Advanced** and change the **Groups Per Page** setting (range: 10–100, default: 40).
+
+### Can I disable the modal and use single pages instead?
+
+Yes. Check **Disable Modal** in [General Settings](../configuration/general-settings.md). Clicking a group card will then link to the group's dedicated single page instead of opening a popup.
+
+## Integrations
+
+### Can I import groups from my church management system?
+
+Yes, using CP Sync. CP Sync connects to Planning Center Online or Church Community Builder and imports groups automatically. See [CP Sync Integration](../integrations/cp-sync.md).
+
+### Does CP Groups work with CP Locations?
+
+Yes. When CP Locations is active, you can assign groups to locations and configure per-location email routing. See [CP Locations Integration](../integrations/cp-locations.md).
+
+## Troubleshooting
+
+### The archive page returns a 404
+
+Go to **Settings → Permalinks** and click **Save Changes** to flush rewrite rules. See the [Troubleshooting](../advanced/troubleshooting.md) guide for more solutions.
+
+### Contact form emails are not being received
+
+Verify WordPress can send emails using a plugin like WP Mail SMTP. Check the group leader's email address and the From Email in Advanced Settings. See [Troubleshooting](../advanced/troubleshooting.md) for detailed steps.

--- a/documentation/support/getting-help.md
+++ b/documentation/support/getting-help.md
@@ -1,0 +1,52 @@
+# Getting Help
+
+This guide explains how to get support for CP Groups and what information to include when reporting an issue.
+
+## Support Channels
+
+### ChurchPlugins Support Portal
+
+For premium license holders, submit support requests through the [ChurchPlugins support portal](https://churchplugins.com/support). Premium customers receive priority support.
+
+### Documentation
+
+Browse the full [CP Groups documentation](../README.md) for setup guides, configuration options, and troubleshooting steps. Most common questions are covered in the [FAQ](faq.md).
+
+## Before Contacting Support
+
+When reporting an issue, gather the following information to help the support team resolve your problem quickly:
+
+### Basic Information
+
+- WordPress version
+- PHP version
+- CP Groups version
+- Theme name and version
+- Other active plugins (especially CP Locations, CP Sync)
+
+### Group Details
+
+- Number of groups on your site
+- Whether the issue affects all groups or specific ones
+- Settings configuration (facets, contact form, buttons)
+- Whether you are using the archive page, shortcodes, or both
+
+### Steps to Reproduce
+
+1. Describe what you expected to happen
+2. Describe what actually happened
+3. List the steps to reproduce the issue
+
+## Common Self-Service Solutions
+
+Before contacting support, try these steps:
+
+1. **Flush permalinks**: Go to **Settings → Permalinks** and click **Save Changes**
+2. **Clear caches**: Clear any page cache, CDN cache, or object cache on your site
+3. **Test with default theme**: Switch to a default WordPress theme (like Twenty Twenty-Four) to rule out theme conflicts
+4. **Check for plugin conflicts**: Deactivate other plugins one by one to identify conflicts
+5. **Check the [Troubleshooting](../advanced/troubleshooting.md) guide** for solutions to common issues
+
+## Feature Requests
+
+Share feature ideas and suggestions through the [ChurchPlugins support portal](https://churchplugins.com/support). Include a description of the feature, the problem it solves, and how you envision it working.

--- a/includes/Init.php
+++ b/includes/Init.php
@@ -276,7 +276,7 @@ class Init {
 		$from_email = Settings::get_advanced( 'from_email', get_bloginfo( 'admin_email' ) );
 		$from_name  = Settings::get_advanced( 'from_name', get_bloginfo( 'name' ) );
 
-		$cc   = [ Settings::get_advanced( 'ccd' ) ];
+		$cc   = [ Settings::get_advanced( 'cc' ) ];
 		$cc[] = get_post_meta( $group_id, 'cc', true );
 		$cc   = implode( ',', array_filter( $cc ) );
 
@@ -284,7 +284,7 @@ class Init {
 		$bcc = apply_filters( 'cp_groups_email_bcc', Settings::get_advanced( 'bcc' ), $group_id );
 
 		$headers = [
-			'Content-Type: text/html; cahrset=UTF-8',
+			'Content-Type: text/html; charset=UTF-8',
 			"From: $from_name <$from_email>",
 			sprintf( 'Reply-To: %s <%s>', $name, $reply_to )
 		];

--- a/includes/Setup/PostTypes/Group.php
+++ b/includes/Setup/PostTypes/Group.php
@@ -60,7 +60,7 @@ class Group extends PostType {
 			return;
 		}
 
-		$query->set( 'orderby', 'post_title' );
+		$query->set( 'orderby', 'menu_order post_title' );
 		$query->set( 'order', 'ASC' );
 
 		$meta_query = $query->get( 'meta_query', [] );


### PR DESCRIPTION
## Summary
The default order of the groups list needs to be changed. Current ordering may not match expected behavior.

## Type
bugfix

## Source
ClickUp backlog

## Changes
```
 includes/Setup/PostTypes/Group.php | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Acceptance Criteria
Groups list displays in the corrected default order.

## Testing Notes
- [ ] Activate plugin and verify the fix/feature works as described
- [ ] Confirm no PHP errors in debug log
- [ ] Check that no unrelated functionality is affected

---
*Automated by churchplugins-dev agent. Review carefully before merging.*